### PR TITLE
Remove decorative lines from captured ePaper display

### DIFF
--- a/gesture_with_capture.py
+++ b/gesture_with_capture.py
@@ -278,11 +278,6 @@ class EpaperUI:
         d.rectangle((x - pad, y - pad, x + tw + pad, y + th + pad), outline=0, fill=255)
         d.text((x, y), banner, font=self.font_big, fill=0)
 
-        # celebratory rays
-        cx = self.W // 2
-        for dx in (-25, 0, 25):
-            d.line((cx + dx, y - 18, cx + dx, y - 4), fill=0, width=2)
-
         # countdown bar
         bar_h = 8
         bar_y0 = self.H - bar_h - 4


### PR DESCRIPTION
## Summary
- remove unnecessary decorative lines from captured ePaper display UI

## Testing
- `python -m py_compile gesture_with_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689cc79fad048322b20bc7211a717151