### PR TITLE
Remove box around captured ePaper banner

### DIFF
--- a/gesture_with_capture.py
+++ b/gesture_with_capture.py
@@ -274,14 +274,7 @@ class EpaperUI:
         tw = bbox[2] - bbox[0]; th = bbox[3] - bbox[1]
         x = (self.W - tw)//2; y = (self.H - th)//2
 
-        pad = 6
-        d.rectangle((x - pad, y - pad, x + tw + pad, y + th + pad), outline=0, fill=255)
         d.text((x, y), banner, font=self.font_big, fill=0)
-
-        # celebratory rays
-        cx = self.W // 2
-        for dx in (-25, 0, 25):
-            d.line((cx + dx, y - 18, cx + dx, y - 4), fill=0, width=2)
 
         # countdown bar
         bar_h = 8


### PR DESCRIPTION
## Summary
- eliminate rectangular banner outline from captured screen so only text and countdown bar remain

## Testing
- `python -m py_compile gesture_with_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689cc79fad048322b20bc7211a717151