### PR TITLE
Log OpenAI identified items to inventory CSV

### DIFF
--- a/gesture_with_capture.py
+++ b/gesture_with_capture.py
@@ -2,6 +2,7 @@ import time, os, collections, threading, queue, base64, datetime
 import numpy as np
 import cv2
 from picamera2 import Picamera2
+from inventory import add_inventory_item
 
 # ─────────────────────────────────────────────────────────────────────────────
 # EPAPER UI (2.13" mono B/W V4) — PARTIAL-ONLY AFTER BOOT (no flashing)
@@ -321,9 +322,33 @@ OPENAI_MODEL   = os.getenv("OPENAI_MODEL", "gpt-5")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 work_q = queue.Queue(maxsize=4)
 WORKER_ALIVE = False
+pending_item = None
+
+def _parse_expiry_date(text: str):
+    text = text.strip()
+    fmts = [
+        "%Y-%m-%d",
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%d %b %Y",
+        "%b %d %Y",
+        "%d %B %Y",
+        "%B %d %Y",
+        "%d-%m-%Y",
+        "%d/%m/%Y",
+        "%d %b %y",
+        "%b %d %y",
+    ]
+    for fmt in fmts:
+        try:
+            dt = datetime.datetime.strptime(text, fmt)
+            return int(dt.timestamp())
+        except Exception:
+            continue
+    return None
 
 def api_worker():
-    global WORKER_ALIVE
+    global WORKER_ALIVE, pending_item
     if OpenAI is None:
         print("[OpenAI] Worker not started: openai SDK not importable."); return
     if not OPENAI_API_KEY:
@@ -366,6 +391,32 @@ def api_worker():
             dt_ms = (time.perf_counter() - t0) * 1000
             text = (resp.choices[0].message.content or "").strip()
             print(f"[OpenAI] ({tag}) {dt_ms:.0f} ms -> {text or '<empty>'}")
+
+            if tag == "check_in":
+                canonical = text.lower()
+                display = text
+                embedding = []
+                try:
+                    emb = client.embeddings.create(model="text-embedding-3-small", input=canonical)
+                    embedding = emb.data[0].embedding
+                except Exception as e:
+                    print(f"[OpenAI] embedding failed: {e}")
+                pending_item = {
+                    "canonical_name": canonical,
+                    "display_name": display,
+                    "embedding": embedding,
+                }
+            elif tag == "expiry":
+                expiry_ts = _parse_expiry_date(text)
+                if pending_item and expiry_ts is not None:
+                    add_inventory_item(
+                        pending_item["canonical_name"],
+                        pending_item["display_name"],
+                        expiry_ts,
+                        pending_item["embedding"],
+                    )
+                    print(f"[inventory] added {pending_item['display_name']} exp={expiry_ts}")
+                    pending_item = None
         except Exception as e:
             print(f"[OpenAI ERROR] tag='{tag}': {type(e).__name__}: {e}")
         finally:

--- a/inventory.py
+++ b/inventory.py
@@ -1,0 +1,22 @@
+import csv
+import json
+import os
+from typing import List
+
+CSV_PATH = os.path.join(os.path.dirname(__file__), 'inventory.csv')
+
+def add_inventory_item(canonical_name: str, display_name: str, expiry_ts: int, embedding: List[float]) -> None:
+    """Append a new inventory record to CSV.
+
+    Loads existing rows, appends the new record, and writes the CSV back to disk.
+    The embedding list is stored as a JSON-encoded string.
+    """
+    rows = []
+    if os.path.exists(CSV_PATH):
+        with open(CSV_PATH, 'r', newline='') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+    rows.append([canonical_name, display_name, str(expiry_ts), json.dumps(embedding)])
+    with open(CSV_PATH, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)


### PR DESCRIPTION
## Summary
- Add `add_inventory_item` helper that appends items to `inventory.csv`.
- Track product and expiration outputs from OpenAI worker, compute embeddings, and store them via `add_inventory_item` once expiry is parsed.
- Parse various date formats to ensure expiration capture completes before the record is finalized.

## Testing
- `python -m py_compile inventory.py gesture_with_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689cfd06e2308322b5ba3662ea511b1c