### PR TITLE
Add vertical swipe fallback

### DIFF
--- a/gesture_with_capture.py
+++ b/gesture_with_capture.py
@@ -808,6 +808,9 @@ try:
         if can_fire and gesture_text == "" and span_x >= SPAN_THR_X and abs(vel_x) >= VEL_THR_X:
             g = "SWIPE_RIGHT" if vel_x > 0 else "SWIPE_LEFT"
             print(f"{g} (span/vel)"); set_mode_and_seed(g); last_fire = now; state_x = "IDLE"; trace_x.clear()
+        if can_fire and gesture_text == "" and span_y >= SPAN_THR_Y and abs(vel_y) >= VEL_THR_Y:
+            g = "SWIPE_DOWN" if vel_y > 0 else "SWIPE_UP"
+            print(f"{g} (span/vel)"); set_mode_and_seed(g); last_fire = now; state_y = "IDLE"; trace_y.clear()
 
         # Expiration prompt timeout
         if awaiting_expiry and (now - expiry_prompt_time) > EXPIRY_WAIT_S:


### PR DESCRIPTION
## Summary
- ensure up/down swipes are detected by adding span/velocity fallback for the Y-axis

## Testing
- `python -m py_compile gesture_with_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689d13b6c5f083229f7abace6e96b0e1